### PR TITLE
Add missing git executable to backend/Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:10-alpine
 WORKDIR /backend
 COPY package* ./
+RUN apk add --no-cache git
 RUN npm install
 COPY . .
 ENV elasticsearch_host db:9200


### PR DESCRIPTION
The node:10-alpine image is missing git, so the `docker-compose up --build` fails:

    Step 4/8 : RUN npm install
     ---> Running in 81dc09d122ed
    npm WARN backend@1.0.0 No repository field.

    npm ERR! code ENOENT
    npm ERR! syscall spawn git
    npm ERR! path git
    npm ERR! errno ENOENT
    npm ERR! enoent Error while executing:
    npm ERR! enoent undefined ls-remote -h -t ssh://git@github.com/rxaviers/assertion.git
    npm ERR! enoent
    npm ERR! enoent
    npm ERR! enoent spawn git ENOENT
    npm ERR! enoent This is related to npm not being able to find a file.
    npm ERR! enoent

I'm not sure how this ever worked before, but the fix is simple, as explained here:

  https://github.com/nodejs/docker-node/issues/586